### PR TITLE
chore: add endOfLine:auto to prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "singleQuote": false,
   "tabWidth": 2,
   "trailingComma": "es5",
-  "printWidth": 100
+  "printWidth": 100,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
## Summary
- Adds `"endOfLine": "auto"` to `.prettierrc` so pre-push `prettier --check` passes on Windows
- No code or formatting changes, single one-line config addition

## Why
On Windows with `core.autocrlf=true`, git converts committed LF to CRLF on checkout. Prettier defaults to `endOfLine: "lf"` and flags every CRLF file as needing reformat, breaking the pre-push hook for every Windows contributor. `"auto"` tells prettier to accept whatever line endings already exist — no effect on macOS/Linux, unblocks Windows.

## Test plan
- [x] `npx prettier --check .` passes locally on Windows after the change
- [x] pre-push hook passes (lint + test + build all green, 386 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)